### PR TITLE
Pin JupyterBook version

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@ conda create -n controls -c anaconda -c conda-forge -c IDAES-PSE python=3.10 pan
 **Instructor/TAs** In the terminal/prompt, type:
 
 ``
-conda create -n controls -c anaconda -c conda-forge -c IDAES-PSE python=3.10 pandas numpy matplotlib scipy jupyterlab nb_conda_kernels pandoc nbconvert-pandoc jupyter-book ghp-import idaes-pse
+conda create -n controls -c anaconda -c conda-forge -c IDAES-PSE python=3.10 pandas numpy matplotlib scipy jupyterlab nb_conda_kernels pandoc nbconvert-pandoc "jupyter-book<2" ghp-import idaes-pse
 ``
 
 **Everyone** Next, in the terminal type:


### PR DESCRIPTION
@MSELab This GitHub repo is configured to automatically rebuild the online textbook (website) with each commit to main. Unfortunately, between last year and now, JupyterBook released a new major version (JupyterBook2) which is not compatible with this repo as structured. As a work around for this semester, I pinned the GitHub actions script and the TA installation instructions to use the old version of JupyterBook. This explains why our commits since November failed to update the website.