### PR TITLE
Replace broken link with archive.org link

### DIFF
--- a/notebooks/3/Proportional-Integral-Control.ipynb
+++ b/notebooks/3/Proportional-Integral-Control.ipynb
@@ -86,7 +86,7 @@
     "    + \\underbrace{K_I \\int^t_0 e(t') dt'}_{\\text{integral}}\n",
     "    + \\underbrace{K_D \\frac{d}{dt}e(t)}_{\\text{derivative}}$$\n",
     "\n",
-    "The [excellent cartoon](https://www.northeastern.edu/landherr/stem-comics/science-comic-pid-controls/) explains the P, I, and D terms as different boxing styles."
+    "The [excellent cartoon](https://web.archive.org/web/20241110063726/https://www.northeastern.edu/landherr/stem-comics/science-comic-pid-controls/) explains the P, I, and D terms as different boxing styles."
    ]
   },
   {

--- a/notebooks/3/Proportional-Integral-Control.ipynb
+++ b/notebooks/3/Proportional-Integral-Control.ipynb
@@ -86,7 +86,7 @@
     "    + \\underbrace{K_I \\int^t_0 e(t') dt'}_{\\text{integral}}\n",
     "    + \\underbrace{K_D \\frac{d}{dt}e(t)}_{\\text{derivative}}$$\n",
     "\n",
-    "The [excellent cartoon](https://web.archive.org/web/20241110063726/https://www.northeastern.edu/landherr/stem-comics/science-comic-pid-controls/) explains the P, I, and D terms as different boxing styles."
+    "This [excellent cartoon](https://web.archive.org/web/20241110063726/https://www.northeastern.edu/landherr/stem-comics/science-comic-pid-controls/) explains the P, I, and D terms as different boxing styles."
    ]
   },
   {


### PR DESCRIPTION
The link to the cartoon under 3.6.3 (feedback control) must have broken at some point in the last couple years; this just changes it to use archive.org instead. I don't know if anyone's clicking on it anyway, but I figured I may as well fix it quickly since I noticed that.

-Jack